### PR TITLE
MultiDocument using acquisition url

### DIFF
--- a/lib/jumio_rock.rb
+++ b/lib/jumio_rock.rb
@@ -4,6 +4,7 @@ require "jumio_rock/netverify_params"
 require "jumio_rock/perform_netverify_params"
 require "jumio_rock/embed_netverify_params"
 require "jumio_rock/multi_document_netverify_params"
+require "jumio_rock/acquisition_netverify_params"
 require "jumio_rock/redirect_netverify_params"
 require "jumio_rock/client"
 require "jumio_rock/post_parser"
@@ -12,5 +13,5 @@ require 'excon'
 require "base64"
 
 module JumioRock
-  
+
 end

--- a/lib/jumio_rock/acquisition_netverify_params.rb
+++ b/lib/jumio_rock/acquisition_netverify_params.rb
@@ -1,0 +1,20 @@
+module JumioRock
+
+  class AcquisitionNetverifyParams < NetverifyParams
+
+    attr_reader :type, :country, :merchantScanReference, :customerId
+    attr_accessor :authorizationTokenLifetime, :merchantReportingCriteria,
+      :successUrl, :errorUrl, :callbackUrl, :clientIp
+
+    def initialize(document_type, country, merchant_scan_reference, customer_id) # , success_url, error_url)
+      @type                  = document_type
+      @country               = country
+      @merchantScanReference = merchant_scan_reference
+      @customerId            = customer_id
+      # @successUrl            = success_url
+      # @errorUrl              = error_url
+    end
+
+  end
+
+end

--- a/lib/jumio_rock/configuration.rb
+++ b/lib/jumio_rock/configuration.rb
@@ -1,15 +1,17 @@
 module JumioRock
   class Configuration
-    attr_accessor :app_name, :company_name, :version, :api_url, :api_token, :api_secret, :init_redirect_url, :init_embed_url, :multi_document_url
+    attr_accessor :app_name, :company_name, :version, :api_url, :api_token, :api_secret,
+      :init_redirect_url, :init_embed_url, :multi_document_url, :acquisitions_url
 
     def initialize
-      self.company_name = 'YOURCOMPANYNAME'
-      self.app_name = 'YOURAPPLICATIONNAME'
-      self.version = VERSION
-      self.api_url = "https://netverify.com/api/netverify/v2/performNetverify"
-      self.init_redirect_url = "https://netverify.com/api/netverify/v2/initiateNetverifyRedirect"
-      self.init_embed_url = "https://netverify.com/api/netverify/v2/initiateNetverify"
+      self.company_name       = 'YOURCOMPANYNAME'
+      self.app_name           = 'YOURAPPLICATIONNAME'
+      self.version            = VERSION
+      self.api_url            = "https://netverify.com/api/netverify/v2/performNetverify"
+      self.init_redirect_url  = "https://netverify.com/api/netverify/v2/initiateNetverifyRedirect"
+      self.init_embed_url     = "https://netverify.com/api/netverify/v2/initiateNetverify"
       self.multi_document_url = "https://netverify.com/api/netverify/v2/createDocumentAcquisition"
+      self.acquisitions_url   = "https://upload.netverify.com/api/netverify/v2/acquisitions"
     end
 
     def self.configuration

--- a/lib/jumio_rock/netverify_params.rb
+++ b/lib/jumio_rock/netverify_params.rb
@@ -1,14 +1,14 @@
 require 'json'
 
 module JumioRock
-  
+
   class NetverifyParams
-    
+
     def to_json
       JSON.generate(params)
     end
 
-    private 
+    private
 
     def params
       data = {}
@@ -20,9 +20,10 @@ module JumioRock
       data
     end
 
-    # attr_reader instance variables must be set 
+    # attr_reader instance variables must be set
     def check_mandatory(data)
       required_params = self.instance_variables.select{|v| !respond_to?("#{v.to_s.gsub('@','')}=")}
+
       required_params.each do |r|
         name = r.to_s.sub('@', '')
         raise "#{name} is a required param" unless data[name]


### PR DESCRIPTION
As described in: jumio-netverify-implementation-guide_v2_4_0.pdf
page: 25

@michelemina, as promised in issue #1 here's the implementation I'm actively using in my project, however, I didn't have time to:
- add options param
- clean it up
- test it
- document it

In addition it would be nice to use your `initialization_type` and `iframe`, instead of my `acquisition_iframe`.

I intend to finish the job but these are busy days, but as I said, I can't schedule it right now.
